### PR TITLE
Demote ntpdate command return error to warning

### DIFF
--- a/bin/ntp_monitor.py
+++ b/bin/ntp_monitor.py
@@ -102,8 +102,9 @@ def ntp_monitor(namespace, offset=500, self_offset=500, diag_hostname = None, er
                     st.message = "NTP offset too high on %s" % namespace
 
             else:
-                st.level = DiagnosticStatus.ERROR
-                st.message = "Error running ntpdate. Returned %d on %s." % (res, namespace)
+                # Warning (not error), since this is a non-critical failure.
+                st.level = DiagnosticStatus.WARN
+                st.message = "Error running ntpdate (returned %d on %s)" % (res, namespace)
                 st.values = [ KeyValue("Offset (us)", "N/A"),
                               KeyValue("Offset tolerance (us)", str(off)),
                               KeyValue("Offset tolerance (us) for Error", str(error_offset)),


### PR DESCRIPTION
- This is a non-critical error that happens somewhat frequently (likely due to
  server pool throttling). To reduce false-positive alarms, we explicitly
  change this to warning level instead of error level.
- Also edit the message to better match mdash formatting when there are multiple
  other warnings/errors (avoid periods within message).

Other notes:
- This seemed like the right place to make this change in general, but idk ¯\\\_(ツ)\_/¯
- Left the error set above for very high offsets as an error.