### PR TITLE
Migrate scripts to mbot Diagnostics 2.0

### DIFF
--- a/bin/cpu_monitor.py
+++ b/bin/cpu_monitor.py
@@ -94,7 +94,10 @@ def update_status_stale(stat, last_update_time):
 
 class CPUMonitor():
     def __init__(self, hostname, namespace, diag_hostname):
-        self._diag_updater = DiagnosticUpdater(namespace + 'cpu')
+        self._diag_updater = DiagnosticUpdater(
+            name=namespace + 'cpu',
+            display_name=diag_hostname + ' CPU',
+        )
 
         self._namespace = namespace
 
@@ -544,9 +547,9 @@ if __name__ == '__main__':
     hostname = hostname.replace('-', '_')
 
     import optparse
-    parser = optparse.OptionParser(usage="usage: cpu_monitor.py [--diag-hostname=cX]")
+    parser = optparse.OptionParser(usage="usage: cpu_monitor.py --diag-hostname=com-X")
     parser.add_option("--diag-hostname", dest="diag_hostname",
-                      help="Computer name in diagnostics output (ex: 'c1')",
+                      help="Computer name in diagnostics output (ex: 'com-1')",
                       metavar="DIAG_HOSTNAME",
                       action="store", default = hostname)
     options, args = parser.parse_args(rospy.myargv())

--- a/bin/cpu_monitor.py
+++ b/bin/cpu_monitor.py
@@ -94,18 +94,12 @@ def update_status_stale(stat, last_update_time):
 
 class CPUMonitor():
     def __init__(self, hostname, namespace, diag_hostname):
-        self._temp_diag_updater = DiagnosticUpdater(
-            '/ros_system_monitor/{}/cpu/temp'.format(namespace)
-        )
-        self._usage_diag_updater = DiagnosticUpdater(
-            '/ros_system_monitor/{}/cpu/usage'.format(namespace)
-        )
+        self._diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/cpu'.format(namespace))
         self._publish_diagnostic = OutputDiagnostic(
             '/publish',
             params=rospy.get_param('~publish_stats_diagnostic_params'),
         )
-        self._publish_diagnostic.add_to_updater(self._temp_diag_updater)
-        self._publish_diagnostic.add_to_updater(self._usage_diag_updater)
+        self._publish_diagnostic.add_to_updater(self._diag_updater)
 
         self._namespace = namespace
 
@@ -137,7 +131,7 @@ class CPUMonitor():
         self._temp_stat.values = [ KeyValue(key = 'Update Status', value = 'No Data' ),
                                    KeyValue(key = 'Time Since Last Update', value = 'N/A') ]
         self._temp_diagnostic = GenericDiagnostic('/temp')
-        self._temp_diagnostic.add_to_updater(self._temp_diag_updater)
+        self._temp_diagnostic.add_to_updater(self._diag_updater)
 
         self._usage_stat = DiagnosticStatus()
         self._usage_stat.name = '%s CPU Usage' % namespace
@@ -147,7 +141,7 @@ class CPUMonitor():
         self._usage_stat.values = [ KeyValue(key = 'Update Status', value = 'No Data' ),
                                     KeyValue(key = 'Time Since Last Update', value = 'N/A') ]
         self._usage_diagnostic = GenericDiagnostic('/usage')
-        self._usage_diagnostic.add_to_updater(self._usage_diag_updater)
+        self._usage_diagnostic.add_to_updater(self._diag_updater)
 
         self._last_temp_time = 0
         self._last_usage_time = 0

--- a/bin/cpu_monitor.py
+++ b/bin/cpu_monitor.py
@@ -55,7 +55,7 @@ import socket
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
 
 from marble_structs.diagnostics import Status
-from mbot_diagnostics import DiagnosticUpdater, GenericDiagnostic, OutputDiagnostic
+from mbot_diagnostics import DiagnosticUpdater, GenericDiagnostic
 
 cpu_load_warn = 0.9
 cpu_load_error = 1.1
@@ -95,11 +95,6 @@ def update_status_stale(stat, last_update_time):
 class CPUMonitor():
     def __init__(self, hostname, namespace, diag_hostname):
         self._diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/cpu'.format(namespace))
-        self._publish_diagnostic = OutputDiagnostic(
-            '/publish',
-            params=rospy.get_param('~publish_stats_diagnostic_params'),
-        )
-        self._publish_diagnostic.add_to_updater(self._diag_updater)
 
         self._namespace = namespace
 
@@ -536,8 +531,6 @@ class CPUMonitor():
             )
             for diag_val in self._usage_stat.values:
                 self._usage_diagnostic.set_metric(diag_val.key, diag_val.value)
-
-            self._publish_diagnostic.tick()
 
 
         # Restart temperature checking if it goes stale, #4171

--- a/bin/cpu_monitor.py
+++ b/bin/cpu_monitor.py
@@ -94,7 +94,7 @@ def update_status_stale(stat, last_update_time):
 
 class CPUMonitor():
     def __init__(self, hostname, namespace, diag_hostname):
-        self._diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/cpu'.format(namespace))
+        self._diag_updater = DiagnosticUpdater(namespace + 'cpu')
 
         self._namespace = namespace
 
@@ -119,7 +119,7 @@ class CPUMonitor():
 
         # CPU stats
         self._temp_stat = DiagnosticStatus()
-        self._temp_stat.name = '%s CPU Temperature' % namespace
+        self._temp_stat.name = 'CPU Temperature'
         self._temp_stat.level = 1
         self._temp_stat.hardware_id = hostname
         self._temp_stat.message = 'No Data'
@@ -129,7 +129,7 @@ class CPUMonitor():
         self._temp_diagnostic.add_to_updater(self._diag_updater)
 
         self._usage_stat = DiagnosticStatus()
-        self._usage_stat.name = '%s CPU Usage' % namespace
+        self._usage_stat.name = 'CPU Usage'
         self._usage_stat.level = 1
         self._usage_stat.hardware_id = hostname
         self._usage_stat.message = 'No Data'
@@ -301,7 +301,7 @@ class CPUMonitor():
             level = DiagnosticStatus.ERROR
             vals.append(KeyValue(key = 'Load Average Status', value = traceback.format_exc()))
 
-        diag_msg = '%s on %s' % (load_dict[level], self._namespace)
+        diag_msg = load_dict[level]
         return level, diag_msg, vals
 
     ##\brief Use mpstat to find CPU usage
@@ -326,7 +326,7 @@ class CPUMonitor():
 
                 mp_level = DiagnosticStatus.ERROR
                 vals.append(KeyValue(key = '\"mpstat\" Call Error', value = str(retcode)))
-                return mp_level, 'Unable to Check CPU Usage on %s' % self._namespace, vals
+                return mp_level, 'Unable to Check CPU Usage', vals
 
             # Check which column '%idle' is, #4539
             # mpstat output changed between 8.06 and 8.1
@@ -393,13 +393,13 @@ class CPUMonitor():
                     rospy.logerr('Error checking number of cores. Expected %d, got %d. Computer may have not booted properly.',
                                   self._num_cores, num_cores)
                     self._has_error_core_count = True
-                return DiagnosticStatus.ERROR, 'Incorrect number of CPU cores on %s' % self._namespace, vals
+                return DiagnosticStatus.ERROR, 'Incorrect number of CPU cores', vals
 
         except Exception, e:
             mp_level = DiagnosticStatus.ERROR
             vals.append(KeyValue(key = 'mpstat Exception', value = str(e)))
 
-        diag_msg = '%s on %s' % (load_dict[mp_level], self._namespace)
+        diag_msg = load_dict[mp_level]
         return mp_level, diag_msg, vals
 
     ## Returns names for core temperature files
@@ -557,9 +557,7 @@ if __name__ == '__main__':
         print >> sys.stderr, 'CPU monitor is unable to initialize node. Master may not be running.'
         sys.exit(0)
 
-    namespace = rospy.get_namespace().replace('/', '')
-    if not namespace:
-        namespace = hostname
+    namespace = rospy.get_namespace() or hostname
 
     cpu_node = CPUMonitor(hostname, namespace, options.diag_hostname)
 

--- a/bin/hdd_monitor.py
+++ b/bin/hdd_monitor.py
@@ -54,7 +54,7 @@ import socket
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
 
 from marble_structs.diagnostics import Status
-from mbot_diagnostics import DiagnosticUpdater, GenericDiagnostic, OutputDiagnostic
+from mbot_diagnostics import DiagnosticUpdater, GenericDiagnostic
 
 hdd_level_warn = 0.95
 hdd_level_error = 0.99
@@ -151,11 +151,6 @@ class hdd_monitor():
         self._temp_timer = None
 
         self._diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/hdd'.format(namespace))
-        self._publish_diagnostic = OutputDiagnostic(
-            '/publish',
-            params=rospy.get_param('~publish_stats_diagnostic_params'),
-        )
-        self._publish_diagnostic.add_to_updater(self._diag_updater)
         self._temp_stat = None
         self._temp_diagnostic = None
         if not self._no_temp:
@@ -357,8 +352,6 @@ class hdd_monitor():
             )
             for diag_val in self._usage_stat.values:
                 self._usage_diagnostic.set_metric(diag_val.key, diag_val.value)
-
-            self._publish_diagnostic.tick()
 
 
 

--- a/bin/hdd_monitor.py
+++ b/bin/hdd_monitor.py
@@ -150,18 +150,12 @@ class hdd_monitor():
         self._last_temp_time = 0
         self._temp_timer = None
 
-        self._temp_diag_updater = DiagnosticUpdater(
-            '/ros_system_monitor/{}/hdd/temp'.format(namespace)
-        )
-        self._usage_diag_updater = DiagnosticUpdater(
-            '/ros_system_monitor/{}/hdd/usage'.format(namespace)
-        )
+        self._diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/hdd'.format(namespace))
         self._publish_diagnostic = OutputDiagnostic(
             '/publish',
             params=rospy.get_param('~publish_stats_diagnostic_params'),
         )
-        self._publish_diagnostic.add_to_updater(self._temp_diag_updater)
-        self._publish_diagnostic.add_to_updater(self._usage_diag_updater)
+        self._publish_diagnostic.add_to_updater(self._diag_updater)
         self._temp_stat = None
         self._temp_diagnostic = None
         if not self._no_temp:
@@ -173,7 +167,7 @@ class hdd_monitor():
             self._temp_stat.values = [ KeyValue(key = 'Update Status', value = 'No Data'),
                                       KeyValue(key = 'Time Since Last Update', value = 'N/A') ]
             self._temp_diagnostic = GenericDiagnostic('/temp')
-            self._temp_diagnostic.add_to_updater(self._temp_diag_updater)
+            self._temp_diagnostic.add_to_updater(self._diag_updater)
             self.check_temps()
 
         self._last_usage_time = 0
@@ -185,7 +179,7 @@ class hdd_monitor():
         self._usage_stat.values = [ KeyValue(key = 'Update Status', value = 'No Data' ),
                                     KeyValue(key = 'Time Since Last Update', value = 'N/A') ]
         self._usage_diagnostic = GenericDiagnostic('/usage')
-        self._usage_diagnostic.add_to_updater(self._usage_diag_updater)
+        self._usage_diagnostic.add_to_updater(self._diag_updater)
         self.check_disk_usage()
 
     ## Must have the lock to cancel everything

--- a/bin/hdd_monitor.py
+++ b/bin/hdd_monitor.py
@@ -150,12 +150,12 @@ class hdd_monitor():
         self._last_temp_time = 0
         self._temp_timer = None
 
-        self._diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/hdd'.format(namespace))
+        self._diag_updater = DiagnosticUpdater(namespace + 'hdd')
         self._temp_stat = None
         self._temp_diagnostic = None
         if not self._no_temp:
             self._temp_stat = DiagnosticStatus()
-            self._temp_stat.name = "%s HDD Temperature" % namespace
+            self._temp_stat.name = "HDD Temperature"
             self._temp_stat.level = DiagnosticStatus.ERROR
             self._temp_stat.hardware_id = hostname
             self._temp_stat.message = 'No Data'
@@ -170,7 +170,7 @@ class hdd_monitor():
         self._usage_stat = DiagnosticStatus()
         self._usage_stat.level = DiagnosticStatus.ERROR
         self._usage_stat.hardware_id = hostname
-        self._usage_stat.name = '%s HDD Usage' % namespace
+        self._usage_stat.name = 'HDD Usage'
         self._usage_stat.values = [ KeyValue(key = 'Update Status', value = 'No Data' ),
                                     KeyValue(key = 'Time Since Last Update', value = 'N/A') ]
         self._usage_diagnostic = GenericDiagnostic('/usage')
@@ -302,7 +302,7 @@ class hdd_monitor():
                             key = 'Disk %d Mount Point' % row_count, value = mount_pt))
 
                     diag_level = max(diag_level, level)
-                    diag_message = '%s on %s' % (usage_dict[diag_level], self._namespace)
+                    diag_message = usage_dict[diag_level]
 
             else:
                 diag_vals.append(KeyValue(key = 'Disk Space Reading', value = 'Failed'))
@@ -376,9 +376,7 @@ if __name__ == '__main__':
         print 'HDD monitor is unable to initialize node. Master may not be running.'
         sys.exit(0)
 
-    namespace = rospy.get_namespace().replace('/', '')
-    if not namespace:
-        namespace = hostname
+    namespace = rospy.get_namespace() or hostname
 
     hdd_monitor = hdd_monitor(hostname, namespace, options.diag_hostname)
     rate = rospy.Rate(1.0)

--- a/bin/hdd_monitor.py
+++ b/bin/hdd_monitor.py
@@ -150,7 +150,10 @@ class hdd_monitor():
         self._last_temp_time = 0
         self._temp_timer = None
 
-        self._diag_updater = DiagnosticUpdater(namespace + 'hdd')
+        self._diag_updater = DiagnosticUpdater(
+            name=namespace + 'hdd',
+            display_name=diag_hostname + ' HDD',
+        )
         self._temp_stat = None
         self._temp_diagnostic = None
         if not self._no_temp:
@@ -363,9 +366,9 @@ if __name__ == '__main__':
     hostname = hostname.replace('-', '_')
 
     import optparse
-    parser = optparse.OptionParser(usage="usage: hdd_monitor.py [--diag-hostname=cX]")
+    parser = optparse.OptionParser(usage="usage: hdd_monitor.py --diag-hostname=com-X")
     parser.add_option("--diag-hostname", dest="diag_hostname",
-                      help="Computer name in diagnostics output (ex: 'c1')",
+                      help="Computer name in diagnostics output (ex: 'com-1')",
                       metavar="DIAG_HOSTNAME",
                       action="store", default = hostname)
     options, args = parser.parse_args(rospy.myargv())

--- a/bin/mem_monitor.py
+++ b/bin/mem_monitor.py
@@ -90,7 +90,7 @@ def update_status_stale(stat, last_update_time):
 
 class MemMonitor():
     def __init__(self, hostname, namespace, diag_hostname):
-        self._diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/mem'.format(namespace))
+        self._diag_updater = DiagnosticUpdater(namespace + 'mem')
 
         self._namespace = namespace;
 
@@ -102,7 +102,7 @@ class MemMonitor():
         self._usage_timer = None
 
         self._usage_stat = DiagnosticStatus()
-        self._usage_stat.name = '%s Memory Usage' % namespace
+        self._usage_stat.name = 'Memory Usage'
         self._usage_stat.level = 1
         self._usage_stat.hardware_id = hostname
         self._usage_stat.message = 'No Data'
@@ -174,10 +174,10 @@ class MemMonitor():
             values.append(KeyValue(key='Available Memory', value="%sM" % available_mem))
             values.append(KeyValue(key='Percent Used', value="%s%%" % int(mem_usage * 100)))
 
-            msg = '%s on %s' % (mem_dict[level], self._namespace)
+            msg = mem_dict[level]
         except Exception, e:
             rospy.logerr(traceback.format_exc())
-            msg = 'Memory usage check error on %s' % self._namespace
+            msg = 'Memory usage check error'
             values.append(KeyValue(key = msg, value = str(e)))
             level = DiagnosticStatus.ERROR
 
@@ -252,9 +252,7 @@ if __name__ == '__main__':
         print >> sys.stderr, 'Memory monitor is unable to initialize node. Master may not be running.'
         sys.exit(0)
 
-    namespace = rospy.get_namespace().replace('/', '')
-    if not namespace:
-        namespace = hostname
+    namespace = rospy.get_namespace() or hostname
 
     mem_node = MemMonitor(hostname, namespace, options.diag_hostname)
 

--- a/bin/mem_monitor.py
+++ b/bin/mem_monitor.py
@@ -54,6 +54,9 @@ import socket
 
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
 
+from marble_structs.diagnostics import Status
+from mbot_diagnostics import DiagnosticUpdater, GenericDiagnostic, OutputDiagnostic
+
 mem_level_warn = 0.95
 mem_level_error = 0.99
 
@@ -87,7 +90,12 @@ def update_status_stale(stat, last_update_time):
 
 class MemMonitor():
     def __init__(self, hostname, namespace, diag_hostname):
-        self._diag_pub = rospy.Publisher('/diagnostics', DiagnosticArray, queue_size = 100)
+        self._diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/mem/usage'.format(namespace))
+        self._publish_diagnostic = OutputDiagnostic(
+            '/publish',
+            params=rospy.get_param('~publish_stats_diagnostic_params'),
+        )
+        self._publish_diagnostic.add_to_updater(self._diag_updater)
 
         self._namespace = namespace;
 
@@ -105,9 +113,10 @@ class MemMonitor():
         self._usage_stat.message = 'No Data'
         self._usage_stat.values = [ KeyValue(key = 'Update Status', value = 'No Data' ),
                                     KeyValue(key = 'Time Since Last Update', value = 'N/A') ]
+        self._usage_diagnostic = GenericDiagnostic('/usage')
+        self._usage_diagnostic.add_to_updater(self._diag_updater)
 
         self._last_usage_time = 0
-        self._last_publish_time = 0
 
         # Start checking everything
         self.check_usage()
@@ -221,13 +230,15 @@ class MemMonitor():
             # Update everything with last update times
             update_status_stale(self._usage_stat, self._last_usage_time)
 
-            msg = DiagnosticArray()
-            msg.header.stamp = rospy.get_rostime()
-            msg.status.append(self._usage_stat)
+            # Convert from ROS diagnostics to mbot_diagnostics for publishing.
+            self._usage_diagnostic.set_status(
+                Status(self._usage_stat.level),
+                self._usage_stat.message,
+            )
+            for diag_val in self._usage_stat.values:
+                self._usage_diagnostic.set_metric(diag_val.key, diag_val.value)
 
-            if rospy.get_time() - self._last_publish_time > 0.5:
-                self._diag_pub.publish(msg)
-                self._last_publish_time = rospy.get_time()
+            self._publish_diagnostic.tick()
 
 
 if __name__ == '__main__':
@@ -251,7 +262,7 @@ if __name__ == '__main__':
     namespace = rospy.get_namespace().replace('/', '')
     if not namespace:
         namespace = hostname
-        
+
     mem_node = MemMonitor(hostname, namespace, options.diag_hostname)
 
     rate = rospy.Rate(1.0)

--- a/bin/mem_monitor.py
+++ b/bin/mem_monitor.py
@@ -90,7 +90,10 @@ def update_status_stale(stat, last_update_time):
 
 class MemMonitor():
     def __init__(self, hostname, namespace, diag_hostname):
-        self._diag_updater = DiagnosticUpdater(namespace + 'mem')
+        self._diag_updater = DiagnosticUpdater(
+            name=namespace + 'mem',
+            display_name=diag_hostname + ' memory',
+        )
 
         self._namespace = namespace;
 
@@ -239,9 +242,9 @@ if __name__ == '__main__':
     hostname = hostname.replace('-', '_')
 
     import optparse
-    parser = optparse.OptionParser(usage="usage: mem_monitor.py [--diag-hostname=cX]")
+    parser = optparse.OptionParser(usage="usage: mem_monitor.py --diag-hostname=com-X")
     parser.add_option("--diag-hostname", dest="diag_hostname",
-                      help="Computer name in diagnostics output (ex: 'c1')",
+                      help="Computer name in diagnostics output (ex: 'com-1')",
                       metavar="DIAG_HOSTNAME",
                       action="store", default = hostname)
     options, args = parser.parse_args(rospy.myargv())

--- a/bin/mem_monitor.py
+++ b/bin/mem_monitor.py
@@ -90,7 +90,7 @@ def update_status_stale(stat, last_update_time):
 
 class MemMonitor():
     def __init__(self, hostname, namespace, diag_hostname):
-        self._diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/mem/usage'.format(namespace))
+        self._diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/mem'.format(namespace))
         self._publish_diagnostic = OutputDiagnostic(
             '/publish',
             params=rospy.get_param('~publish_stats_diagnostic_params'),

--- a/bin/mem_monitor.py
+++ b/bin/mem_monitor.py
@@ -55,7 +55,7 @@ import socket
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
 
 from marble_structs.diagnostics import Status
-from mbot_diagnostics import DiagnosticUpdater, GenericDiagnostic, OutputDiagnostic
+from mbot_diagnostics import DiagnosticUpdater, GenericDiagnostic
 
 mem_level_warn = 0.95
 mem_level_error = 0.99
@@ -91,11 +91,6 @@ def update_status_stale(stat, last_update_time):
 class MemMonitor():
     def __init__(self, hostname, namespace, diag_hostname):
         self._diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/mem'.format(namespace))
-        self._publish_diagnostic = OutputDiagnostic(
-            '/publish',
-            params=rospy.get_param('~publish_stats_diagnostic_params'),
-        )
-        self._publish_diagnostic.add_to_updater(self._diag_updater)
 
         self._namespace = namespace;
 
@@ -237,8 +232,6 @@ class MemMonitor():
             )
             for diag_val in self._usage_stat.values:
                 self._usage_diagnostic.set_metric(diag_val.key, diag_val.value)
-
-            self._publish_diagnostic.tick()
 
 
 if __name__ == '__main__':

--- a/bin/net_monitor.py
+++ b/bin/net_monitor.py
@@ -104,7 +104,7 @@ def get_sys_net(iface, sys):
 
 class NetMonitor():
   def __init__(self, hostname, namespace, diag_hostname):
-    self._diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/net'.format(namespace))
+    self._diag_updater = DiagnosticUpdater(namespace + 'net')
 
     self._namespace = namespace
     self._mutex = threading.Lock()
@@ -112,7 +112,7 @@ class NetMonitor():
     self._net_capacity = rospy.get_param('~net_capacity', net_capacity)
     self._usage_timer = None
     self._usage_stat = DiagnosticStatus()
-    self._usage_stat.name = '%s Network Usage' % namespace
+    self._usage_stat.name = 'Network Usage'
     self._usage_stat.level = 1
     self._usage_stat.hardware_id = hostname
     self._usage_stat.message = 'No Data'
@@ -197,7 +197,7 @@ class NetMonitor():
       msg = 'Network Usage Check Error'
       values.append(KeyValue(key = msg, value = str(e)))
       level = DiagnosticStatus.ERROR
-    diag_msg = '%s on %s' % (net_dict[level], self._namespace)
+    diag_msg = net_dict[level]
     return level, diag_msg, values
 
   def check_usage(self):
@@ -260,9 +260,7 @@ if __name__ == '__main__':
     print >> sys.stderr,\
       'Network monitor is unable to initialize node. Master may not be running.'
     sys.exit(0)
-  namespace = rospy.get_namespace().replace('/', '')
-  if not namespace:
-    namespace = hostname
+  namespace = rospy.get_namespace() or hostname
   net_node = NetMonitor(hostname, namespace, options.diag_hostname)
   rate = rospy.Rate(1.0)
   try:

--- a/bin/net_monitor.py
+++ b/bin/net_monitor.py
@@ -56,7 +56,7 @@ import socket
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
 
 from marble_structs.diagnostics import Status
-from mbot_diagnostics import DiagnosticUpdater, GenericDiagnostic, OutputDiagnostic
+from mbot_diagnostics import DiagnosticUpdater, GenericDiagnostic
 
 net_level_warn = 0.95
 net_capacity = 128
@@ -105,11 +105,6 @@ def get_sys_net(iface, sys):
 class NetMonitor():
   def __init__(self, hostname, namespace, diag_hostname):
     self._diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/net'.format(namespace))
-    self._publish_diagnostic = OutputDiagnostic(
-      '/publish',
-      params=rospy.get_param('~publish_stats_diagnostic_params'),
-    )
-    self._publish_diagnostic.add_to_updater(self._diag_updater)
 
     self._namespace = namespace
     self._mutex = threading.Lock()
@@ -245,8 +240,6 @@ class NetMonitor():
       )
       for diag_val in self._usage_stat.values:
         self._usage_diagnostic.set_metric(diag_val.key, diag_val.value)
-
-      self._publish_diagnostic.tick()
 
 if __name__ == '__main__':
   hostname = socket.gethostname()

--- a/bin/net_monitor.py
+++ b/bin/net_monitor.py
@@ -55,6 +55,9 @@ import socket
 
 from diagnostic_msgs.msg import DiagnosticArray, DiagnosticStatus, KeyValue
 
+from marble_structs.diagnostics import Status
+from mbot_diagnostics import DiagnosticUpdater, GenericDiagnostic, OutputDiagnostic
+
 net_level_warn = 0.95
 net_capacity = 128
 
@@ -101,7 +104,13 @@ def get_sys_net(iface, sys):
 
 class NetMonitor():
   def __init__(self, hostname, namespace, diag_hostname):
-    self._diag_pub = rospy.Publisher('/diagnostics', DiagnosticArray, queue_size = 100)
+    self._diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/net/usage'.format(namespace))
+    self._publish_diagnostic = OutputDiagnostic(
+      '/publish',
+      params=rospy.get_param('~publish_stats_diagnostic_params'),
+    )
+    self._publish_diagnostic.add_to_updater(self._diag_updater)
+
     self._namespace = namespace
     self._mutex = threading.Lock()
     self._net_level_warn = rospy.get_param('~net_level_warn', net_level_warn)
@@ -116,8 +125,9 @@ class NetMonitor():
                                value = 'No Data' ),
                                KeyValue(key = 'Time Since Last Update',
                                value = 'N/A') ]
+    self._usage_diagnostic = GenericDiagnostic('/usage')
+    self._usage_diagnostic.add_to_updater(self._diag_updater)
     self._last_usage_time = 0
-    self._last_publish_time = 0
     self.check_usage()
 
   def cancel_timers(self):
@@ -227,12 +237,16 @@ class NetMonitor():
   def publish_stats(self):
     with self._mutex:
       update_status_stale(self._usage_stat, self._last_usage_time)
-      msg = DiagnosticArray()
-      msg.header.stamp = rospy.get_rostime()
-      msg.status.append(self._usage_stat)
-      if rospy.get_time() - self._last_publish_time > 0.5:
-        self._diag_pub.publish(msg)
-        self._last_publish_time = rospy.get_time()
+
+      # Convert from ROS diagnostics to mbot_diagnostics for publishing.
+      self._usage_diagnostic.set_status(
+        Status(self._usage_stat.level),
+        self._usage_stat.message,
+      )
+      for diag_val in self._usage_stat.values:
+        self._usage_diagnostic.set_metric(diag_val.key, diag_val.value)
+
+      self._publish_diagnostic.tick()
 
 if __name__ == '__main__':
   hostname = socket.gethostname()

--- a/bin/net_monitor.py
+++ b/bin/net_monitor.py
@@ -104,7 +104,10 @@ def get_sys_net(iface, sys):
 
 class NetMonitor():
   def __init__(self, hostname, namespace, diag_hostname):
-    self._diag_updater = DiagnosticUpdater(namespace + 'net')
+    self._diag_updater = DiagnosticUpdater(
+      name=namespace + 'net',
+      display_name=diag_hostname + ' network',
+    )
 
     self._namespace = namespace
     self._mutex = threading.Lock()
@@ -248,9 +251,9 @@ if __name__ == '__main__':
   import optparse
   parser =\
     optparse.OptionParser(
-    usage="usage: net_monitor.py [--diag-hostname=cX]")
+    usage="usage: net_monitor.py --diag-hostname=com-X")
   parser.add_option("--diag-hostname", dest="diag_hostname",
-                    help="Computer name in diagnostics output (ex: 'c1')",
+                    help="Computer name in diagnostics output (ex: 'com-1')",
                     metavar="DIAG_HOSTNAME",
                     action="store", default = hostname)
   options, args = parser.parse_args(rospy.myargv())

--- a/bin/net_monitor.py
+++ b/bin/net_monitor.py
@@ -104,7 +104,7 @@ def get_sys_net(iface, sys):
 
 class NetMonitor():
   def __init__(self, hostname, namespace, diag_hostname):
-    self._diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/net/usage'.format(namespace))
+    self._diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/net'.format(namespace))
     self._publish_diagnostic = OutputDiagnostic(
       '/publish',
       params=rospy.get_param('~publish_stats_diagnostic_params'),

--- a/bin/ntp_monitor.py
+++ b/bin/ntp_monitor.py
@@ -54,7 +54,10 @@ NAME = 'ntp_monitor'
 
 def ntp_monitor(namespace, offset=500, self_offset=500, diag_hostname = None, error_offset = 5000000):
     rospy.init_node(NAME, anonymous=True)
-    diag_updater = DiagnosticUpdater(namespace + 'ntp')
+    diag_updater = DiagnosticUpdater(
+        name=namespace + 'ntp',
+        display_name=diag_hostname + ' NTP',
+    )
 
     hostname = socket.gethostname()
     if diag_hostname is None:
@@ -126,7 +129,7 @@ def ntp_monitor(namespace, offset=500, self_offset=500, diag_hostname = None, er
 
 def ntp_monitor_main(argv=sys.argv):
     import optparse
-    parser = optparse.OptionParser(usage="usage: ntp_monitor ntp-hostname []")
+    parser = optparse.OptionParser(usage="usage: ntp_monitor --diag-hostname=com-X []")
     parser.add_option("--offset-tolerance", dest="offset_tol",
                       action="store", default=500,
                       help="Offset from NTP host", metavar="OFFSET-TOL")
@@ -137,9 +140,9 @@ def ntp_monitor_main(argv=sys.argv):
                       action="store", default=500,
                       help="Offset from self", metavar="SELF_OFFSET-TOL")
     parser.add_option("--diag-hostname", dest="diag_hostname",
-                      help="Computer name in diagnostics output (ex: 'c1')",
+                      help="Computer name in diagnostics output (ex: 'com-1')",
                       metavar="DIAG_HOSTNAME",
-                      action="store", default=None)
+                      action="store", default='com-?')
     options, args = parser.parse_args(rospy.myargv())
 
 #    if (len(args) != 2):

--- a/bin/ntp_monitor.py
+++ b/bin/ntp_monitor.py
@@ -54,7 +54,7 @@ NAME = 'ntp_monitor'
 
 def ntp_monitor(namespace, offset=500, self_offset=500, diag_hostname = None, error_offset = 5000000):
     rospy.init_node(NAME, anonymous=True)
-    diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/ntp'.format(namespace))
+    diag_updater = DiagnosticUpdater(namespace + 'ntp')
 
     hostname = socket.gethostname()
     if diag_hostname is None:
@@ -66,7 +66,7 @@ def ntp_monitor(namespace, offset=500, self_offset=500, diag_hostname = None, er
 
     stat = DiagnosticStatus()
     stat.level = 0
-    stat.name = "%s NTP Offset" % namespace
+    stat.name = "NTP Offset"
     stat.message = "OK"
     stat.hardware_id = hostname
     stat.values = []
@@ -101,15 +101,15 @@ def ntp_monitor(namespace, offset=500, self_offset=500, diag_hostname = None, er
 
                 if (abs(measured_offset) > off):
                     st.level = DiagnosticStatus.WARN
-                    st.message = "NTP offset too high on %s" % namespace
+                    st.message = "NTP offset too high"
                 if (abs(measured_offset) > error_offset):
                     st.level = DiagnosticStatus.ERROR
-                    st.message = "NTP offset too high on %s" % namespace
+                    st.message = "NTP offset too high"
 
             else:
                 # Warning (not error), since this is a non-critical failure.
                 st.level = DiagnosticStatus.WARN
-                st.message = "Error running ntpdate (returned %d on %s)" % (res, namespace)
+                st.message = "Error running ntpdate (returned %d)" % res
                 st.values = [ KeyValue("Offset (us)", "N/A"),
                               KeyValue("Offset tolerance (us)", str(off)),
                               KeyValue("Offset tolerance (us) for Error", str(error_offset)),
@@ -153,9 +153,7 @@ def ntp_monitor_main(argv=sys.argv):
     except:
         parser.error("Offsets must be numbers")
 
-    namespace = rospy.get_namespace().replace('/', '')
-    if not namespace:
-        namespace = hostname
+    namespace = rospy.get_namespace() or hostname
 
     ntp_monitor(namespace, offset, self_offset, options.diag_hostname, error_offset)
 

--- a/bin/ntp_monitor.py
+++ b/bin/ntp_monitor.py
@@ -54,7 +54,7 @@ NAME = 'ntp_monitor'
 
 def ntp_monitor(namespace, offset=500, self_offset=500, diag_hostname = None, error_offset = 5000000):
     rospy.init_node(NAME, anonymous=True)
-    diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/ntp/offset'.format(namespace))
+    diag_updater = DiagnosticUpdater('/ros_system_monitor/{}/ntp'.format(namespace))
 
     hostname = socket.gethostname()
     if diag_hostname is None:

--- a/config/system_monitor.yaml
+++ b/config/system_monitor.yaml
@@ -6,9 +6,6 @@ cpu_monitor:
   cpu_load5_warn: 0.8
   cpu_temp_warn: 85.0
   cpu_temp_error: 90.0
-  publish_stats_diagnostic_params:
-    freq_warning_thresholds:
-      max_interval_sec: 20.0
 hdd_monitor:
   no_hdd_temp: true
   no_hdd_temp_warn: false
@@ -16,15 +13,9 @@ hdd_monitor:
   hdd_level_error: 0.99
   hdd_temp_warn: 55.0
   hdd_temp_error: 70.0
-  publish_stats_diagnostic_params:
-    freq_warning_thresholds:
-      max_interval_sec: 20.0
 mem_monitor:
   mem_level_warn: 0.95
   mem_level_error: 0.99
-  publish_stats_diagnostic_params:
-    freq_warning_thresholds:
-      max_interval_sec: 20.0
 ntp_monitor:
   reference_host: ntp.ubuntu.com
   offset_tolerance: 500.0
@@ -32,6 +23,3 @@ ntp_monitor:
 net_monitor:
   net_level_warn: 0.95
   net_capacity: 128.0
-  publish_stats_diagnostic_params:
-    freq_warning_thresholds:
-      max_interval_sec: 20.0

--- a/config/system_monitor.yaml
+++ b/config/system_monitor.yaml
@@ -6,6 +6,9 @@ cpu_monitor:
   cpu_load5_warn: 0.8
   cpu_temp_warn: 85.0
   cpu_temp_error: 90.0
+  publish_stats_diagnostic_params:
+    freq_warning_thresholds:
+      max_interval_sec: 20.0
 hdd_monitor:
   no_hdd_temp: true
   no_hdd_temp_warn: false
@@ -13,9 +16,15 @@ hdd_monitor:
   hdd_level_error: 0.99
   hdd_temp_warn: 55.0
   hdd_temp_error: 70.0
+  publish_stats_diagnostic_params:
+    freq_warning_thresholds:
+      max_interval_sec: 20.0
 mem_monitor:
   mem_level_warn: 0.95
   mem_level_error: 0.99
+  publish_stats_diagnostic_params:
+    freq_warning_thresholds:
+      max_interval_sec: 20.0
 ntp_monitor:
   reference_host: ntp.ubuntu.com
   offset_tolerance: 500.0
@@ -23,3 +32,6 @@ ntp_monitor:
 net_monitor:
   net_level_warn: 0.95
   net_capacity: 128.0
+  publish_stats_diagnostic_params:
+    freq_warning_thresholds:
+      max_interval_sec: 20.0


### PR DESCRIPTION
For each monitor, internal stats are unchanged, but publishing is
done through mbot Diagnostics 2.0.

Required for https://github.com/MarbleInc/mbot/pull/3196.

**Please do not squash merge.**